### PR TITLE
feat(profile): show account email on the profile page

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -138,10 +138,13 @@ class AdminController extends OCSController {
 				$forumUsersByUserId[$forumUser->getUserId()] = $forumUser;
 			}
 
-			// Collect all user IDs first
+			// Collect all user IDs and emails first (the IUser is only
+			// available inside this callback)
 			$userIds = [];
-			$this->userManager->callForAllUsers(function ($user) use (&$userIds) {
+			$emailsByUserId = [];
+			$this->userManager->callForAllUsers(function ($user) use (&$userIds, &$emailsByUserId) {
 				$userIds[] = $user->getUID();
+				$emailsByUserId[$user->getUID()] = $this->userService->getUserEmail($user);
 			});
 
 			// Enrich all users at once for performance (includes roles)
@@ -156,6 +159,7 @@ class AdminController extends OCSController {
 				$userData = [
 					'userId' => $userId,
 					'displayName' => $userInfo['displayName'],
+					'email' => $emailsByUserId[$userId] ?? null,
 					'postCount' => $forumUser ? $forumUser->getPostCount() : 0,
 					'threadCount' => $forumUser ? $forumUser->getThreadCount() : 0,
 					'createdAt' => $forumUser ? $forumUser->getCreatedAt() : 0,

--- a/lib/Controller/ForumUserController.php
+++ b/lib/Controller/ForumUserController.php
@@ -126,6 +126,13 @@ class ForumUserController extends OCSController {
 			$roles = $this->roleMapper->findByUserId($userId);
 			$data['roles'] = array_map(fn ($role) => $role->jsonSerialize(), $roles);
 
+			// Email visibility follows Nextcloud semantics: the primary email
+			// can never be scoped private, so any authenticated viewer may see
+			// it. Unauthenticated guests never receive the field.
+			if ($this->userSession->getUser() !== null) {
+				$data['email'] = $this->userService->getUserEmailById($userId);
+			}
+
 			return new DataResponse($data);
 		} catch (\Exception $e) {
 			$this->logger->error('Error fetching forum user: ' . $e->getMessage());

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -12,8 +12,11 @@ use OCA\Forum\Db\ForumUserMapper;
 use OCA\Forum\Db\Role;
 use OCA\Forum\Db\RoleMapper;
 use OCA\Forum\Db\UserRoleMapper;
+use OCP\Accounts\IAccountManager;
+use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IL10N;
+use OCP\IUser;
 use OCP\IUserManager;
 
 /**
@@ -31,6 +34,7 @@ class UserService {
 		private AdminSettingsService $adminSettingsService,
 		private GuestService $guestService,
 		private IL10N $l10n,
+		private IAccountManager $accountManager,
 	) {
 	}
 
@@ -46,6 +50,40 @@ class UserService {
 
 		// User doesn't exist in Nextcloud - return generic deleted user name
 		return $this->l10n->t('Deleted user');
+	}
+
+	/**
+	 * Get the email address of a user, honoring the Nextcloud account scope
+	 * Returns null if the user has no email or has it scoped as private
+	 */
+	public function getUserEmail(IUser $user): ?string {
+		try {
+			$property = $this->accountManager->getAccount($user)
+				->getProperty(IAccountManager::PROPERTY_EMAIL);
+			if ($property->getScope() === IAccountManager::SCOPE_PRIVATE) {
+				// Nextcloud never allows a private scope on the primary email,
+				// but legacy data could still carry it - never expose those
+				return null;
+			}
+		} catch (PropertyDoesNotExistException) {
+			// No explicit account property: treat as the default visible scope
+		}
+
+		$email = $user->getEMailAddress();
+		return ($email === null || $email === '') ? null : $email;
+	}
+
+	/**
+	 * Get the email address for a Nextcloud user ID
+	 * Returns null if the user does not exist in Nextcloud
+	 */
+	public function getUserEmailById(string $userId): ?string {
+		$user = $this->userManager->get($userId);
+		if ($user === null) {
+			return null;
+		}
+
+		return $this->getUserEmail($user);
 	}
 
 	/**

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -107,6 +107,7 @@ export interface Post {
 
 export interface ForumUser {
   userId: string
+  email?: string | null
   postCount: number
   threadCount: number
   lastPostAt: number | null

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -78,6 +78,12 @@
                 }}</span>
                 <span class="meta-value">{{ forumUser?.postCount || 0 }}</span>
               </span>
+              <template v-if="forumUser?.email">
+                <span class="meta-divider">·</span>
+                <span class="meta-item">
+                  <a :href="`mailto:${forumUser.email}`">{{ forumUser.email }}</a>
+                </span>
+              </template>
             </div>
           </div>
         </div>

--- a/src/views/__tests__/ProfileView.test.ts
+++ b/src/views/__tests__/ProfileView.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createIconMock, createComponentMock } from '@/test-utils'
+
+// Uses global mock for @/axios from test-setup.ts
+
+vi.mock('@nextcloud/auth', () => ({
+  getCurrentUser: () => ({ uid: 'alice', displayName: 'Alice' }),
+}))
+
+vi.mock('@icons/ArrowLeft.vue', () => createIconMock('ArrowLeftIcon'))
+vi.mock('@icons/Refresh.vue', () => createIconMock('RefreshIcon'))
+
+vi.mock('@/components/PageWrapper', () =>
+  createComponentMock('PageWrapper', {
+    template: '<div class="page-wrapper-mock"><slot name="toolbar" /><slot /></div>',
+  }),
+)
+
+vi.mock('@/components/AppToolbar', () =>
+  createComponentMock('AppToolbar', {
+    template: '<div class="app-toolbar-mock"><slot name="left" /><slot name="right" /></div>',
+  }),
+)
+
+vi.mock('@/components/ThreadCard', () =>
+  createComponentMock('ThreadCard', {
+    template: '<div class="thread-card-mock" />',
+    props: ['thread'],
+  }),
+)
+
+import ProfileView from '../ProfileView.vue'
+import { ocs } from '@/axios'
+
+const mockOcsGet = vi.mocked(ocs.get)
+
+function createForumUserResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    userId: 'alice',
+    postCount: 5,
+    threadCount: 2,
+    lastPostAt: null,
+    deletedAt: null,
+    createdAt: 1700000000,
+    updatedAt: 1700000000,
+    roles: [],
+    ...overrides,
+  }
+}
+
+function mockProfileResponses(forumUser: Record<string, unknown>) {
+  mockOcsGet.mockImplementation((url: string) => {
+    if (url === '/users/alice') {
+      return Promise.resolve({ data: forumUser })
+    }
+    // '/users/alice/threads' and '/users/alice/posts'
+    return Promise.resolve({ data: [] })
+  })
+}
+
+const createWrapper = () =>
+  mount(ProfileView, {
+    global: {
+      mocks: {
+        $route: { params: { userId: 'alice' } },
+        $router: { back: vi.fn(), push: vi.fn() },
+      },
+    },
+  })
+
+describe('ProfileView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a mailto link when the response includes an email', async () => {
+    mockProfileResponses(createForumUserResponse({ email: 'alice@example.com' }))
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    const link = wrapper.find('a[href="mailto:alice@example.com"]')
+    expect(link.exists()).toBe(true)
+    expect(link.text()).toBe('alice@example.com')
+  })
+
+  it('renders no email element when the response has no email', async () => {
+    mockProfileResponses(createForumUserResponse())
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    expect(wrapper.find('a[href^="mailto:"]').exists()).toBe(false)
+  })
+
+  it('renders no email element when the email is null', async () => {
+    mockProfileResponses(createForumUserResponse({ email: null }))
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    expect(wrapper.find('a[href^="mailto:"]').exists()).toBe(false)
+  })
+})

--- a/src/views/admin/AdminUserList.vue
+++ b/src/views/admin/AdminUserList.vue
@@ -39,6 +39,11 @@
           </UserInfo>
         </template>
 
+        <template #cell-email="{ row }">
+          <a v-if="row.email" :href="`mailto:${row.email}`">{{ row.email }}</a>
+          <span v-else class="muted">—</span>
+        </template>
+
         <template #cell-posts="{ row }">
           <div class="post-stats">
             <div class="stat-item">
@@ -160,6 +165,7 @@ import type { Role } from '@/types'
 interface AdminUser {
   userId: string
   displayName: string
+  email: string | null
   postCount: number
   threadCount: number
   createdAt: number
@@ -211,6 +217,7 @@ export default defineComponent({
         emptyTitle: t('forum', 'No accounts found'),
         emptyDesc: t('forum', 'There are no forum accounts yet'),
         user: t('forum', 'Account'),
+        email: t('forum', 'Email'),
         posts: t('forum', 'Replies'),
         roles: t('forum', 'Roles'),
         joined: t('forum', 'Joined'),
@@ -240,6 +247,7 @@ export default defineComponent({
     tableColumns(): TableColumn[] {
       return [
         { key: 'user', label: this.strings.user, minWidth: '200px' },
+        { key: 'email', label: this.strings.email, minWidth: '180px' },
         { key: 'posts', label: this.strings.posts, minWidth: '160px' },
         { key: 'roles', label: this.strings.roles, minWidth: '150px' },
         { key: 'joined', label: this.strings.joined, minWidth: '120px' },

--- a/src/views/admin/__tests__/AdminUserList.test.ts
+++ b/src/views/admin/__tests__/AdminUserList.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createIconMock, createComponentMock } from '@/test-utils'
+
+// Uses global mock for @/axios from test-setup.ts
+
+vi.mock('@icons/Pencil.vue', () => createIconMock('PencilIcon'))
+
+vi.mock('@/components/PageWrapper', () =>
+  createComponentMock('PageWrapper', {
+    template: '<div class="page-wrapper-mock"><slot /></div>',
+  }),
+)
+
+vi.mock('@/components/PageHeader', () =>
+  createComponentMock('PageHeader', {
+    template: '<div class="page-header-mock">{{ title }}</div>',
+    props: ['title', 'subtitle'],
+  }),
+)
+
+vi.mock('@/components/UserInfo', () =>
+  createComponentMock('UserInfo', {
+    template: '<div class="user-info-mock" :data-user-id="userId"><slot name="meta" /></div>',
+    props: ['userId', 'displayName', 'avatarSize'],
+  }),
+)
+
+vi.mock('@/components/RoleBadge', () =>
+  createComponentMock('RoleBadge', {
+    template: '<span class="role-badge-mock">{{ role?.name }}</span>',
+    props: ['role', 'density'],
+  }),
+)
+
+vi.mock('@nextcloud/vue/components/NcActions', () => ({
+  default: {
+    name: 'NcActions',
+    template: '<div class="nc-actions-mock"><slot /></div>',
+    props: ['variant'],
+  },
+}))
+
+vi.mock('@nextcloud/vue/components/NcActionButton', () => ({
+  default: {
+    name: 'NcActionButton',
+    template:
+      '<button class="nc-action-button-mock" @click="$emit(\'click\')"><slot name="icon" /></button>',
+    props: ['ariaLabel', 'title'],
+  },
+}))
+
+import AdminUserList from '../AdminUserList.vue'
+import { ocs } from '@/axios'
+
+const mockOcsGet = vi.mocked(ocs.get)
+
+function createAdminUser(overrides: Record<string, unknown> = {}) {
+  return {
+    userId: 'alice',
+    displayName: 'Alice',
+    email: 'alice@example.com',
+    postCount: 5,
+    threadCount: 2,
+    createdAt: 1700000000,
+    updatedAt: 1700000000,
+    deletedAt: null,
+    isDeleted: false,
+    roles: [],
+    ...overrides,
+  }
+}
+
+function mockUsersResponse(users: unknown[]) {
+  mockOcsGet.mockImplementation((url: string) => {
+    if (url === '/admin/users') {
+      return Promise.resolve({ data: { users } })
+    }
+    // '/roles'
+    return Promise.resolve({ data: [] })
+  })
+}
+
+describe('AdminUserList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the Email column header', async () => {
+    mockUsersResponse([createAdminUser()])
+    const wrapper = mount(AdminUserList)
+    await flushPromises()
+
+    expect(wrapper.find('.header-row').text()).toContain('Email')
+  })
+
+  it('renders the email as a mailto link', async () => {
+    mockUsersResponse([createAdminUser()])
+    const wrapper = mount(AdminUserList)
+    await flushPromises()
+
+    const link = wrapper.find('a[href="mailto:alice@example.com"]')
+    expect(link.exists()).toBe(true)
+    expect(link.text()).toBe('alice@example.com')
+  })
+
+  it('shows a dash when the user has no email', async () => {
+    mockUsersResponse([createAdminUser({ userId: 'bob', displayName: 'Bob', email: null })])
+    const wrapper = mount(AdminUserList)
+    await flushPromises()
+
+    expect(wrapper.find('a[href^="mailto:"]').exists()).toBe(false)
+    expect(wrapper.find('.col-email .muted').text()).toBe('—')
+  })
+})

--- a/tests/unit/Controller/AdminControllerTest.php
+++ b/tests/unit/Controller/AdminControllerTest.php
@@ -380,4 +380,60 @@ class AdminControllerTest extends TestCase {
 
 		$this->assertEquals(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
 	}
+
+	// ── Users list tests ─────────────────────────────────────────────
+
+	public function testUsersIncludesEmailForEachUser(): void {
+		$alice = $this->createMock(IUser::class);
+		$alice->method('getUID')->willReturn('alice');
+		$bob = $this->createMock(IUser::class);
+		$bob->method('getUID')->willReturn('bob');
+
+		$this->forumUserMapper->method('findAll')->willReturn([]);
+		$this->userManager->method('callForAllUsers')
+			->willReturnCallback(function (callable $callback) use ($alice, $bob): void {
+				$callback($alice);
+				$callback($bob);
+			});
+		$this->userService->method('enrichMultipleUsers')
+			->with(['alice', 'bob'])
+			->willReturn([
+				'alice' => ['displayName' => 'Alice', 'isDeleted' => false, 'roles' => []],
+				'bob' => ['displayName' => 'Bob', 'isDeleted' => false, 'roles' => []],
+			]);
+		$this->userService->method('getUserEmail')
+			->willReturnCallback(
+				fn (IUser $user): ?string => $user->getUID() === 'alice' ? 'alice@example.com' : null,
+			);
+
+		$response = $this->controller->users();
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$users = $response->getData()['users'];
+		$this->assertCount(2, $users);
+		$this->assertSame('alice', $users[0]['userId']);
+		$this->assertSame('alice@example.com', $users[0]['email']);
+		$this->assertSame('bob', $users[1]['userId']);
+		$this->assertNull($users[1]['email']);
+	}
+
+	public function testUsersEmailKeyIsAlwaysPresent(): void {
+		$carol = $this->createMock(IUser::class);
+		$carol->method('getUID')->willReturn('carol');
+
+		$this->forumUserMapper->method('findAll')->willReturn([]);
+		$this->userManager->method('callForAllUsers')
+			->willReturnCallback(function (callable $callback) use ($carol): void {
+				$callback($carol);
+			});
+		$this->userService->method('enrichMultipleUsers')
+			->willReturn(['carol' => ['displayName' => 'Carol', 'isDeleted' => false, 'roles' => []]]);
+		$this->userService->method('getUserEmail')->willReturn(null);
+
+		$response = $this->controller->users();
+
+		$users = $response->getData()['users'];
+		$this->assertArrayHasKey('email', $users[0]);
+		$this->assertNull($users[0]['email']);
+	}
 }

--- a/tests/unit/Controller/ForumUserControllerTest.php
+++ b/tests/unit/Controller/ForumUserControllerTest.php
@@ -155,6 +155,56 @@ class ForumUserControllerTest extends TestCase {
 		$this->assertEquals([], $data['roles']);
 	}
 
+	public function testShowIncludesEmailForAuthenticatedViewer(): void {
+		$viewer = $this->createMock(IUser::class);
+		$viewer->method('getUID')->willReturn('viewer');
+		$this->userSession->method('getUser')->willReturn($viewer);
+
+		$this->forumUserMapper->method('find')
+			->with('user1')
+			->willReturn($this->createForumUser(1, 'user1', 10));
+		$this->userService->method('getUserEmailById')
+			->with('user1')
+			->willReturn('user1@example.com');
+
+		$response = $this->controller->show('user1');
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('user1@example.com', $response->getData()['email']);
+	}
+
+	public function testShowOmitsEmailForUnauthenticatedViewer(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$this->forumUserMapper->method('find')
+			->with('user1')
+			->willReturn($this->createForumUser(1, 'user1', 10));
+
+		$response = $this->controller->show('user1');
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertArrayNotHasKey('email', $response->getData());
+	}
+
+	public function testShowReturnsNullEmailWhenTargetUserHasNone(): void {
+		$viewer = $this->createMock(IUser::class);
+		$viewer->method('getUID')->willReturn('viewer');
+		$this->userSession->method('getUser')->willReturn($viewer);
+
+		$this->forumUserMapper->method('find')
+			->with('user1')
+			->willReturn($this->createForumUser(1, 'user1', 10));
+		$this->userService->method('getUserEmailById')
+			->with('user1')
+			->willReturn(null);
+
+		$response = $this->controller->show('user1');
+
+		$data = $response->getData();
+		$this->assertArrayHasKey('email', $data);
+		$this->assertNull($data['email']);
+	}
+
 	public function testCreateForumUserSuccessfully(): void {
 		$nextcloudUserId = 'new-user';
 		$createdUser = $this->createForumUser(1, $nextcloudUserId, 0);

--- a/tests/unit/Service/UserServiceTest.php
+++ b/tests/unit/Service/UserServiceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Forum\Tests\Service;
+
+use OCA\Forum\Db\BBCodeMapper;
+use OCA\Forum\Db\ForumUserMapper;
+use OCA\Forum\Db\RoleMapper;
+use OCA\Forum\Db\UserRoleMapper;
+use OCA\Forum\Service\AdminSettingsService;
+use OCA\Forum\Service\BBCodeService;
+use OCA\Forum\Service\GuestService;
+use OCA\Forum\Service\UserService;
+use OCP\Accounts\IAccount;
+use OCP\Accounts\IAccountManager;
+use OCP\Accounts\IAccountProperty;
+use OCP\Accounts\PropertyDoesNotExistException;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class UserServiceTest extends TestCase {
+	private UserService $service;
+	/** @var IUserManager&MockObject */
+	private IUserManager $userManager;
+	/** @var IAccountManager&MockObject */
+	private IAccountManager $accountManager;
+
+	protected function setUp(): void {
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->accountManager = $this->createMock(IAccountManager::class);
+
+		$this->service = new UserService(
+			$this->userManager,
+			$this->createMock(ForumUserMapper::class),
+			$this->createMock(RoleMapper::class),
+			$this->createMock(UserRoleMapper::class),
+			$this->createMock(BBCodeMapper::class),
+			$this->createMock(BBCodeService::class),
+			$this->createMock(AdminSettingsService::class),
+			$this->createMock(GuestService::class),
+			$this->createMock(IL10N::class),
+			$this->accountManager,
+		);
+	}
+
+	// ── getUserEmail ─────────────────────────────────────────────────
+
+	public function testGetUserEmailReturnsEmailWhenScopeIsNotPrivate(): void {
+		$user = $this->createUserWithEmailScope('alice@example.com', IAccountManager::SCOPE_LOCAL);
+
+		$this->assertSame('alice@example.com', $this->service->getUserEmail($user));
+	}
+
+	public function testGetUserEmailReturnsNullWhenScopeIsPrivate(): void {
+		$user = $this->createUserWithEmailScope('alice@example.com', IAccountManager::SCOPE_PRIVATE);
+
+		$this->assertNull($this->service->getUserEmail($user));
+	}
+
+	public function testGetUserEmailReturnsNullWhenUserHasNoEmail(): void {
+		$user = $this->createUserWithEmailScope(null, IAccountManager::SCOPE_FEDERATED);
+
+		$this->assertNull($this->service->getUserEmail($user));
+	}
+
+	public function testGetUserEmailReturnsNullWhenEmailIsEmptyString(): void {
+		$user = $this->createUserWithEmailScope('', IAccountManager::SCOPE_LOCAL);
+
+		$this->assertNull($this->service->getUserEmail($user));
+	}
+
+	public function testGetUserEmailReturnsEmailWhenAccountPropertyMissing(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('bob@example.com');
+
+		$account = $this->createMock(IAccount::class);
+		$account->method('getProperty')
+			->with(IAccountManager::PROPERTY_EMAIL)
+			->willThrowException(new PropertyDoesNotExistException(IAccountManager::PROPERTY_EMAIL));
+		$this->accountManager->method('getAccount')->with($user)->willReturn($account);
+
+		$this->assertSame('bob@example.com', $this->service->getUserEmail($user));
+	}
+
+	// ── getUserEmailById ─────────────────────────────────────────────
+
+	public function testGetUserEmailByIdReturnsNullWhenUserDoesNotExist(): void {
+		$this->userManager->method('get')->with('ghost')->willReturn(null);
+
+		$this->assertNull($this->service->getUserEmailById('ghost'));
+	}
+
+	public function testGetUserEmailByIdDelegatesToGetUserEmail(): void {
+		$user = $this->createUserWithEmailScope('carol@example.com', IAccountManager::SCOPE_LOCAL);
+		$this->userManager->method('get')->with('carol')->willReturn($user);
+
+		$this->assertSame('carol@example.com', $this->service->getUserEmailById('carol'));
+	}
+
+	/**
+	 * @param string|null $email Value returned by IUser::getEMailAddress()
+	 */
+	private function createUserWithEmailScope(?string $email, string $scope): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn($email);
+
+		$property = $this->createMock(IAccountProperty::class);
+		$property->method('getScope')->willReturn($scope);
+
+		$account = $this->createMock(IAccount::class);
+		$account->method('getProperty')
+			->with(IAccountManager::PROPERTY_EMAIL)
+			->willReturn($property);
+
+		$this->accountManager->method('getAccount')->with($user)->willReturn($account);
+
+		return $user;
+	}
+}


### PR DESCRIPTION
  ## Summary

  Shows the Nextcloud account email on the **user profile page** (as a meta entry next to Created /
  Threads / Replies) and as a new **Email column** in **Account management**. Both render a `mailto:`
  link; accounts without a visible email get an em dash.

  The forum never stores the address — it is read from the Nextcloud account per request, honoring the
  account's own privacy scope.

  ## Changes

  **Backend**

  - `UserService::getUserEmail()` / `getUserEmailById()`: scope-aware lookup through `IAccountManager`.
    Returns `null` for a missing, empty or private-scoped email; falls back to
    `IUser::getEMailAddress()` when the account property does not exist.
  - `AdminController::users()`: adds `email` per row, collected inside the `callForAllUsers()` callback
    (the only place the `IUser` is available). Still gated by `#[RequirePermission('canManageUsers')]`.
  - `ForumUserController::show()`: adds `email` **only for authenticated sessions**. The route is a
    `#[PublicPage]`, so guests get a response without the key at all.

  **Frontend**

  - `ForumUser.email?: string | null` in `models.ts`.
  - `ProfileView.vue`: `mailto:` link, rendered only when the API returned an email.
  - `AdminUserList.vue`: new `email` column, ellipsised and shown in full on hover. Adds one
    translatable string, `Email`.

  ## Why logged-in users can see it (Nextcloud permission semantics)

  Nextcloud has no single "email is public" flag: each account property carries its own visibility
  scope — `Private`, `Local`, `Federated`, `Published` — evaluated per property. Two server facts drive
  this PR:

  1. **The primary email can never be `Private`.** From the admin manual: *"`PROPERTY_DISPLAYNAME` and
     `PROPERTY_EMAIL` cannot be set to `Private`; server-side enforcement requires at least `Local`."*
     Enforced in `AccountManager::testPropertyScope()` and `buildDefaultUserRecord()`.
  2. **`Local` already means visible to every logged-in user of the instance** — the same address is
     reachable today via the contacts menu, share/mention autocomplete and the system address book.
  1. **The primary email can never be `Private`.** From the admin manual: *"`PROPERTY_DISPLAYNAME` and
     `PROPERTY_EMAIL` cannot be set to `Private`; server-side enforcement requires at least `Local`."*
     Enforced in `AccountManager::testPropertyScope()` and `buildDefaultUserRecord()`.
  2. **`Local` already means visible to every logged-in user of the instance** — the same address is
     reachable today via the contacts menu, share/mention autocomplete and the system address book.

  So this does not widen the audience Nextcloud itself grants, and is in fact stricter on two points:
  guests never receive the field (Nextcloud's `Local` also covers some public contexts), and a legacy
  record carrying a private scope returns `null` instead of being trusted. The admin column adds the
  `canManageUsers` permission on top.

  Reference: <https://docs.nextcloud.com/server/latest/admin_manual/configuration_user/profile_configuration.html#property-visibility-scopes>

  ## Tests

  Written before the implementation, covering the visibility rules rather than the happy path: private
  scope, missing/empty email, missing account property, unknown user ID, authenticated vs. guest
  viewer, the `email` key always present in the admin payload, and the frontend rendering (link, hover
  title, `—` placeholder).

  Local run on this branch: PHPUnit `OK (532 tests, 1954 assertions)`, Vitest `907 tests / 53 files`.

  ## AI disclosure

  This PR was produced with AI assistance for the implementation, tests and this description. It was reviewed
  by a human, the suites above were run locally, and the permission semantics were checked against the
  official documentation and the server source